### PR TITLE
fix: installation scripts for all OSs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -114,5 +114,13 @@ function sidebarCommands(): DefaultTheme.SidebarItem[] {
             text: 'Version',
             link: 'version',
         },
+        {
+            text: 'Doctor',
+            link: 'doctor',
+        },
+        {
+            text: 'Changelog',
+            link: 'changelog',
+        },
     ];
 }

--- a/src/commands/changelog.md
+++ b/src/commands/changelog.md
@@ -1,0 +1,60 @@
+# `changelog`
+
+## Description
+
+Prints the changelog for BuildCLI.
+
+## Usage
+
+```bash
+buildcli changelog [options]
+```
+
+## Options
+
+| Option             | Description                                                                                                               |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `--version`, `-v`  | Release version to label the generated changelog (e.g., 1.2.3). If not specified, use the latest Git tag or 'Unreleased'. |
+| `--format`, `-f`   | Output format. Supported: markdown, html and json. (default: markdown)                                                    |
+| `--output`, `-o`   | The output file to write the changelog to. If not specified, will use 'CHANGELOG.\<format\>'.                             |
+| `--include`, `-i`  | Comma-separated list of commit types to include (default: all).                                                           |
+
+## Examples
+
+### Example 1
+
+Generate a changelog in markdown format.
+
+```bash
+buildcli changelog
+```
+
+### Example 2
+
+Generate a changelog for a specific version.
+
+```bash
+buildcli changelog --version 1.2.3
+```
+
+### Example 3
+
+Generate a changelog in HTML format and save to a specific file.
+
+```bash
+buildcli changelog --format html --output changelog.html
+```
+
+### Example 4
+
+Include only specific commit types in the changelog.
+
+```bash
+buildcli changelog --include feat,fix
+```
+
+## See Also
+
+- [doctor](doctor.md)
+- [project](project.md)
+- [autocomplete](autocomplete.md)

--- a/src/commands/doctor.md
+++ b/src/commands/doctor.md
@@ -1,0 +1,41 @@
+# `doctor`
+
+## Description
+
+Analyzes the environment to ensure all necessary tools and dependencies are available and functioning correctly. Provides subcommands for diagnosing issues and applying fixes, ensuring smooth execution of other commands.
+
+## Usage
+
+```bash
+buildcli doctor [subcommand]
+```
+
+## Options
+
+| Option          | Description                                                                                              |
+|-----------------|----------------------------------------------------------------------------------------------------------|
+| `scan`          | Performs a comprehensive scan of the environment to check for required tools, their installation status, versions, and readiness (e.g., running state for Docker). Provides detailed instructions for installing missing tools. |
+| `fix`         | Scans the environment for required tools and dependencies, identifies issues, and attempts to automatically resolve them. This command ensures the build system is properly configured and ready for use.                         |
+
+## Examples
+
+### Example 1
+
+Perform a comprehensive scan to ensure all necessary tools are installed and configured correctly.
+
+```bash
+buildcli doctor scan
+```
+
+### Example 2
+
+Automatically identify and resolve issues with required tools and dependencies.
+
+```bash
+buildcli doctor fix
+```
+
+## See Also
+
+- [project](project.md)
+- [autocomplete](autocomplete.md)

--- a/src/installation.md
+++ b/src/installation.md
@@ -2,6 +2,7 @@
 
 > [!IMPORTANT] Pre-requisites
 > Before installing BuildCLI, ensure that you have the following prerequisites installed on your system:
+>
 > - [Git](https://git-scm.com/downloads)
 > - [Java Development Kit (JDK)](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
 > - [Apache Maven](https://maven.apache.org/download.cgi)
@@ -15,16 +16,20 @@ development process.
 ::: code-group
 
 ```bash [Windows]
+@echo off
 setlocal
 git clone https://github.com/BuildCLI/BuildCLI.git
 cd BuildCLI
 mvn clean package
-mkdir %USERPROFILE%\bin
-copy target\buildcli.jar %USERPROFILE%\bin\buildcli.jar
+if not exist "%USERPROFILE%\bin" mkdir "%USERPROFILE%\bin"
+copy /Y cli\target\buildcli.jar "%USERPROFILE%\bin\buildcli.jar"
 (
-    echo java -jar "%%USERPROFILE%%\bin\buildcli.jar" %%*
-) > %USERPROFILE%\bin\buildcli.bat
-setx PATH "%PATH%;%USERPROFILE%\bin"
+ echo @echo off
+ echo java --enable-preview --add-modules jdk.incubator.vector -jar "%%USERPROFILE%%\bin\buildcli.jar"
+) > "%USERPROFILE%\bin\buildcli.bat"
+echo %PATH% | findstr /I "%USERPROFILE%\bin" >nul || (
+ setx PATH "%PATH%;%USERPROFILE%\bin"
+)
 endlocal
 ```
 
@@ -32,7 +37,8 @@ endlocal
 git clone https://github.com/BuildCLI/BuildCLI.git 
 cd BuildCLI
 mvn clean package
-cp target/buildcli.jar "$HOME/bin/"
+mkdir -p "$HOME/bin"
+cp cli/target/buildcli.jar "$HOME/bin/"
 cat <<EOF > "$HOME/bin/buildcli"
 #!/bin/bash
 java -jar "\$HOME/bin/buildcli.jar" "\$@"
@@ -46,7 +52,8 @@ source ~/.bashrc
 git clone https://github.com/BuildCLI/BuildCLI.git 
 cd BuildCLI
 mvn clean package
-cp target/buildcli.jar "$HOME/bin/"
+mkdir -p "$HOME/bin"
+cp cli/target/buildcli.jar "$HOME/bin/"
 cat <<EOF > "$HOME/bin/buildcli"
 #!/bin/bash
 java -jar "\$HOME/bin/buildcli.jar" "\$@"


### PR DESCRIPTION
# Description
Fix for [issue 13](https://github.com/BuildCLI/website/issues/13)

There were more incorrect commands for Windows as reported and fixed by @omatheusmesmo . I added the new script to this PR as well.

# Changes
For Windows:
- creates the bin directory if it does not already exists.
- adjusted the correct path for buildcli.jar
- corrected other commands

For Linux and Mac:
- `mkdir -p "$HOME/bin"` creates the bin directory if it does not already exists.
- `cp cli/target/buildcli.jar "$HOME/bin/"`  uses the correct path for buildcli.jar

# Testing
1. Check if the website is showing the new instructions.
2. Follow the instructions to install BuildCli on your machine. 